### PR TITLE
Set up JSR-303 entity validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifier.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifier.java
@@ -32,8 +32,8 @@ public class OidcIdentifier implements Serializable, Comparable<OidcIdentifier> 
      * @param subject the sub claim
      */
     public OidcIdentifier(String issuer, String subject) {
-        this.issuer = issuer;
-        this.subject = subject;
+        this.issuer = Objects.requireNonNull(issuer);
+        this.subject = Objects.requireNonNull(subject);
     }
 
     /**

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifier.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifier.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.persistence.Embeddable;
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Value object representing an OpenID Connect sub claim and the issuer. This will initially be how OIDC users are identified
@@ -15,8 +16,10 @@ public class OidcIdentifier implements Serializable, Comparable<OidcIdentifier> 
 
     private static final long serialVersionUID = 1L;
 
+    @NotEmpty
     private String issuer;
 
+    @NotEmpty
     private String subject;
 
     /**

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifier.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifier.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 import javax.persistence.Embeddable;
+import javax.validation.constraints.NotEmpty;
 
 /**
  * Value object representing a SAML authentication identifier. Initially this will be composed of the entityID of the
@@ -15,8 +16,10 @@ public class SamlIdentifier implements Serializable, Comparable<SamlIdentifier> 
 
     private static final long serialVersionUID = 1L;
 
+    @NotEmpty
     private String entityId;
 
+    @NotEmpty
     private String scopedAffiliation;
 
     /**

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifier.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifier.java
@@ -32,8 +32,8 @@ public class SamlIdentifier implements Serializable, Comparable<SamlIdentifier> 
      * @param scopedAffiliation the value of the eduPersonScopedAffiliation attribute released by the issuer
      */
     public SamlIdentifier(String entityId, String scopedAffiliation) {
-        this.entityId = entityId;
-        this.scopedAffiliation = scopedAffiliation;
+        this.entityId = Objects.requireNonNull(entityId);
+        this.scopedAffiliation = Objects.requireNonNull(scopedAffiliation);
     }
 
     /**

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/Subscriber.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/Subscriber.java
@@ -10,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
+import javax.validation.constraints.NotEmpty;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscriber.OidcIdentifierCommandDto;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscriber.SamlIdentifierCommandDto;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscriber.SubscriberNameCommandDto;
@@ -27,6 +28,7 @@ public class Subscriber implements Serializable {
     @GeneratedValue(generator = "subscriber_id_gen")
     private Long id;
 
+    @NotEmpty
     private String subscriberName;
 
     @ElementCollection

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/Subscriber.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/Subscriber.java
@@ -10,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscriber.OidcIdentifierCommandDto;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscriber.SamlIdentifierCommandDto;
@@ -31,10 +32,12 @@ public class Subscriber implements Serializable {
     @NotEmpty
     private String subscriberName;
 
+    @Valid
     @ElementCollection
     @CollectionTable(name = "saml_identifier")
     private Set<SamlIdentifier> samlIdentifiers = new HashSet<>();
 
+    @Valid
     @ElementCollection
     @CollectionTable(name = "oidc_identifier")
     private Set<OidcIdentifier> oidcIdentifiers = new HashSet<>();

--- a/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscription/Subscription.java
+++ b/src/main/java/uk/co/zodiac2000/subscriptionmanager/domain/subscription/Subscription.java
@@ -7,6 +7,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscription.SubscriptionContentIdentifierCommandDto;
 import uk.co.zodiac2000.subscriptionmanager.transfer.subscription.SubscriptionDatesCommandDto;
 
@@ -29,8 +31,10 @@ public class Subscription implements Serializable {
 
     private boolean terminated;
 
+    @NotEmpty
     private String contentIdentifier;
 
+    @NotNull
     private Long subscriberId;
 
     /**

--- a/src/test/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifierTest.java
+++ b/src/test/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/OidcIdentifierTest.java
@@ -25,6 +25,22 @@ public class OidcIdentifierTest {
     }
 
     /**
+     * Test constructor when issuer is null.
+     */
+    @Test(expectedExceptions = {NullPointerException.class})
+    public void testConstructorIssuerNull() {
+        OidcIdentifier identifier = new OidcIdentifier(null, SUBJECT_ONE);
+    }
+
+    /**
+     * Test constructor when subject is null.
+     */
+    @Test(expectedExceptions = {NullPointerException.class})
+    public void testConstructorSubjectNull() {
+        OidcIdentifier identifier = new OidcIdentifier(ISSUER_ONE, null);
+    }
+
+    /**
      * Test equals when argument is null.
      */
     @Test

--- a/src/test/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifierTest.java
+++ b/src/test/java/uk/co/zodiac2000/subscriptionmanager/domain/subscriber/SamlIdentifierTest.java
@@ -25,6 +25,22 @@ public class SamlIdentifierTest {
     }
 
     /**
+     * Test constructor when entityId is null.
+     */
+    @Test(expectedExceptions = {NullPointerException.class})
+    public void testConstructorEntityIdNull() {
+        SamlIdentifier identifier = new SamlIdentifier(null, SCOPED_AFFILIATION_ONE);
+    }
+
+    /**
+     * Test constructor when scopedAffiliation is null.
+     */
+    @Test(expectedExceptions = {NullPointerException.class})
+    public void testConstructorScopedAffiliationNull() {
+        SamlIdentifier identifier = new SamlIdentifier(ENTITY_ID_ONE, null);
+    }
+
+    /**
      * Test equals when argument is null.
      */
     @Test


### PR DESCRIPTION
# Overview

Validation set up for Subscription and Subscriber aggregates enforced when objects are persisted.

Also added constraints that subscriber identifier fields cannot be null because that breaks the Comparable contract these classes implement.

# Details

* Subscription.contentIdentifier: not empty
* Subscription.subscriberId: not null. Note at present SubscriptionFactory fails to parse the string representation of this number when null.
* Subscriber.subscriberName: not empty
* OidcIdentifier.issuer: not empty
* OidcIdentifier.subject: not empty
* SamlIdentifier.entityId: not empty
* SamlIdentifier.scopedAffiliation: not empty
