### PR TITLE
#35 executable jar name now has suffix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <classifier>exec</classifier>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
A standard jar is created alongside the executable spring-boot jar, which has a -exec suffix.